### PR TITLE
Increase version of Font Awesome to 5.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": ">=5.4.0",
     "yiisoft/yii2": "~2.0.0",
-    "fortawesome/font-awesome": "~4.7"
+    "fortawesome/font-awesome": "^5.11"
   },
   "autoload": {
     "psr-4": {

--- a/src/FontawesomeAsset.php
+++ b/src/FontawesomeAsset.php
@@ -20,6 +20,10 @@ class FontawesomeAsset extends \yii\web\AssetBundle
     public $css = [
         'css/all.min.css',
     ];
+    
+    public $js = [
+        'js/all.min.js'
+    ];
 
     /**
      * @var string CDN version for CDN mode, eg. `'4.7.0'`

--- a/src/FontawesomeAsset.php
+++ b/src/FontawesomeAsset.php
@@ -18,7 +18,7 @@ class FontawesomeAsset extends \yii\web\AssetBundle
     public $sourcePath = '@vendor/fortawesome/font-awesome';
 
     public $css = [
-        'css/font-awesome.min.css',
+        'css/all.min.css',
     ];
 
     /**


### PR DESCRIPTION
The version 4.7 is pretty outdated, this PR raises the version to 5.11.
Please note, that CDN is only supported for version 4.7.